### PR TITLE
Lock down xlrd to restore .xlsx support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyexcel-io>=0.6.2
-xlrd
+xlrd<2
 xlwt

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ PYTHON_REQUIRES = ">=3.6"
 
 INSTALL_REQUIRES = [
     "pyexcel-io>=0.6.2",
-    "xlrd",
+    "xlrd<2",
     "xlwt",
 ]
 SETUP_COMMANDS = {}


### PR DESCRIPTION
The readme says it supports .xlsx, but [xlrd released v2 this morning](https://pypi.org/project/xlrd/2.0.1/) which removes .xlsx support. Since this is unpinned, it's broken as is right now.

With your PR, here is a check list:

- [ ] Has test cases written?
- [ ] Has all code lines tested?
- [ ] Has `make format` been run?
- [ ] Please update CHANGELOG.yml(not CHANGELOG.rst)
- [ ] Has fair amount of documentation if your change is complex
- [ ] Agree on NEW BSD License for your contribution
